### PR TITLE
Update code example to import `LookerClient` from `looker.client` ins…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Within your Looker, navigate to admin, manager users, then either create a new A
 Using the Looker Python SDK
 ---------------------
 
-    from looker import LookerClient
+    from looker.client import LookerClient
 
     # instantiate LookerClient
     client = LookerClient('<token>',


### PR DESCRIPTION
The code example does not work.

The class `LookerClient` must be imported from `looker.client` instead of `looker`, as showcased in `sample.py`.